### PR TITLE
fix import path

### DIFF
--- a/test_vgg16.py
+++ b/test_vgg16.py
@@ -1,8 +1,8 @@
 import numpy as np
 import tensorflow as tf
 
-from tensoflow_vgg import vgg16
-from tensoflow_vgg import utils
+import vgg16
+import utils
 
 img1 = utils.load_image("./test_data/tiger.jpeg")
 img2 = utils.load_image("./test_data/puzzle.jpeg")

--- a/test_vgg19.py
+++ b/test_vgg19.py
@@ -1,8 +1,8 @@
 import numpy as np
 import tensorflow as tf
 
-from tensoflow_vgg import vgg19
-from tensoflow_vgg import utils
+import vgg19
+import utils
 
 img1 = utils.load_image("./test_data/tiger.jpeg")
 img2 = utils.load_image("./test_data/puzzle.jpeg")

--- a/test_vgg19_trainable.py
+++ b/test_vgg19_trainable.py
@@ -4,8 +4,8 @@ Simple tester for the vgg19_trainable
 
 import tensorflow as tf
 
-from tensoflow_vgg import vgg19_trainable as vgg19
-from tensoflow_vgg import utils
+import vgg19_trainable as vgg19
+import utils
 
 img1 = utils.load_image("./test_data/tiger.jpeg")
 img1_true_result = [1 if i == 292 else 0 for i in range(1000)]  # 1-hot result for tiger


### PR DESCRIPTION
Hi machrisaa,

Thank you for sharing this amazing project.

In test_vgg16.py, test_vgg19.py, and test_vgg19_trainable, I think there are some typos.
It seems that `tensoflow_vgg` should be corrected to `tensorflow_vgg`, right?
Despite changing those typos (I assume they are) and adding `sys.path.append("../")`, it doesn't match the name of your github project.

So, I made some changes to help those who want to test your project very quickly.

```
-from tensoflow_vgg import vgg16
-from tensoflow_vgg import utils
+import vgg16
+import utils
```