### PR TITLE
set allow_pickle True 

### DIFF
--- a/vgg16.py
+++ b/vgg16.py
@@ -17,7 +17,7 @@ class Vgg16:
             vgg16_npy_path = path
             print(path)
 
-        self.data_dict = np.load(vgg16_npy_path, encoding='latin1').item()
+        self.data_dict = np.load(vgg16_npy_path, encoding='latin1', allow_pickle=True).item()
         print("npy file loaded")
 
     def build(self, rgb):

--- a/vgg19.py
+++ b/vgg19.py
@@ -17,7 +17,7 @@ class Vgg19:
             vgg19_npy_path = path
             print(vgg19_npy_path)
 
-        self.data_dict = np.load(vgg19_npy_path, encoding='latin1').item()
+        self.data_dict = np.load(vgg19_npy_path, encoding='latin1', allow_pickle=True).item()
         print("npy file loaded")
 
     def build(self, rgb):

--- a/vgg19_trainable.py
+++ b/vgg19_trainable.py
@@ -13,7 +13,7 @@ class Vgg19:
 
     def __init__(self, vgg19_npy_path=None, trainable=True, dropout=0.5):
         if vgg19_npy_path is not None:
-            self.data_dict = np.load(vgg19_npy_path, encoding='latin1').item()
+            self.data_dict = np.load(vgg19_npy_path, encoding='latin1', allow_pickle=True).item()
         else:
             self.data_dict = None
 


### PR DESCRIPTION
When i execute this project on my machine , numpy.load(vgg19.npy) throw a err;

```bash
Traceback (most recent call last):
  File "test_vgg19.py", line 21, in <module>
    vgg = vgg19.Vgg19()
  File "/Users/wanglei/AICS-Course/Code/tensorflow-vgg/vgg19.py", line 20, in __init__
    self.data_dict = np.load(vgg19_npy_path, encoding='latin1').item()
  File "/Users/wanglei/opt/anaconda3/lib/python3.7/site-packages/numpy/lib/npyio.py", line 453, in load
    pickle_kwargs=pickle_kwargs)
  File "/Users/wanglei/opt/anaconda3/lib/python3.7/site-packages/numpy/lib/format.py", line 739, in read_array
    raise ValueError("Object arrays cannot be loaded when "
ValueError: Object arrays cannot be loaded when allow_pickle=False
```

I notice that my numpy version is 1.18.3，and the default value of allow_pickle was setted to False after the numpy version 1.17 released，so i give a value true explicitly.

The effect of allow_pickle can be seen here:
![image](https://user-images.githubusercontent.com/34334180/105802365-f64f5880-5fd5-11eb-9253-c383ae619a0b.png)
