### PR TITLE
Spelling error corrected.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Tensorflow VGG16 and VGG19
 
-This is a Tensorflow implemention of VGG 16 and VGG 19 based on [tensorflow-vgg16](https://github.com/ry/tensorflow-vgg16) and [Caffe to Tensorflow](https://github.com/ethereon/caffe-tensorflow). Original Caffe implementation can be found in [here](https://gist.github.com/ksimonyan/211839e770f7b538e2d8) and [here](https://gist.github.com/ksimonyan/3785162f95cd2d5fee77).
+This is a Tensorflow implementation of VGG 16 and VGG 19 based on [tensorflow-vgg16](https://github.com/ry/tensorflow-vgg16) and [Caffe to Tensorflow](https://github.com/ethereon/caffe-tensorflow). Original Caffe implementation can be found in [here](https://gist.github.com/ksimonyan/211839e770f7b538e2d8) and [here](https://gist.github.com/ksimonyan/3785162f95cd2d5fee77).
 
 We have modified the implementation of <a href="https://github.com/ry/tensorflow-vgg16">tensorflow-vgg16</a> to use numpy loading instead of default tensorflow model loading in order to speed up the initialisation and reduce the overall memory usage. This implementation enable further modify the network, e.g. remove the FC layers, or increase the batch size.
 


### PR DESCRIPTION
There is a spelling error in the first line of the readme section. The sentence is written as, " This is a Tensorflow implemention of VGG 16 and VGG 19 based on....."
The word 'implemention' is wrongly misspelled here.
The correct sentence could be written as, " This is a Tensorflow implementation of VGG 16 and VGG 19 based on....."
Thank you.